### PR TITLE
Ajout de sommaires pour naviguer plus facilement depuis github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# discord
+# Discord
 
 Règles et gestion du serveur Discord de programmation Not a Name : https://discord.gg/zcWp9sC
 
@@ -6,3 +6,14 @@ Règles et gestion du serveur Discord de programmation Not a Name : https://disc
 
 Ce repository représente le serveur Discord et son organisation, ses règles, etc.
 Vous pouvez suggérer une modification en créant une issue ou une pull request.
+
+# Sommaire
+
+- [Bots](bots.md)
+- [Canaux](canaux.md)
+- [Commandes Bots](commandes-bots.md)
+- [FAQ](faq.md)
+- [Lives](live/README.md)
+- [Projets](projets/README.md)
+- [Règles](règles.md)
+- [Staff](staff.md)

--- a/live/README.md
+++ b/live/README.md
@@ -2,4 +2,10 @@
 
 Le serveur met en place un système de notification et d'annonce lorsqu'un streameur de la communauté (approuvé par le staff) démarre un live sur Twitch.
 
-Chaque streameur est représenté par un fichier portant le nom de sa chaîne
+Chaque streameur est représenté par un fichier portant le nom de sa chaîne.
+
+# Liste des streamers actuels
+
+- [HardCPP](hardcpp.md)
+- [L0lock](l0lock.md)
+- [SirLynixVanFrietjes](sirlynixvanfrietjes.md)

--- a/projets/README.md
+++ b/projets/README.md
@@ -1,3 +1,19 @@
 # Projets
 
 Not a Name propose un canal dédié à certains projets réalisés par les membres de la communauté.
+
+# Liste des projets actuels
+
+- [Cycle](cycle.md)
+- [Factorio](factorio.md)
+- [Hand 2 Hand](hand2hand.md)
+- [Nazara Engine](nazara.md)
+- [Neuroshok](neuroshok.md)
+- [ProjectW](projectw.md)
+- [RaZ](raz.md)
+- [RetroDev](retrodev.md)
+- [RPiSequencer](rpisequencer.md)
+- [Sielo](sielo.md)
+- [Skift](skift.md)
+- [Starxium](starxium.md)
+- [Utopia](utopia.md)


### PR DESCRIPTION
En ce qui concerne les projets, j'aurai trouvé ça intéressant de mettre un bref descriptif de chaque projet dans le sommaire du readme projets. 
Cela éviterait d'aller parcourir tous les projets pour savoir de quoi il s'agit.