### PR TITLE
Mise à jour du tag discord de Lynix

### DIFF
--- a/live/sirlynixvanfrietjes.md
+++ b/live/sirlynixvanfrietjes.md
@@ -1,5 +1,5 @@
 Chaine: https://twitch.tv/sirlynixvanfrietjes
-Membre: Lynix#9999 (83928726282174464)
+Membre: Lynix#3516 (83928726282174464)
 
 ## Présentation
 

--- a/projets/nazara.md
+++ b/projets/nazara.md
@@ -2,5 +2,5 @@
 
 Moteur de jeu complet écrit en C++14.
 
-Auteur: Lynix#9999 (83928726282174464)
+Auteur: Lynix#3516 (83928726282174464)
 Description du salon: https://github.com/DigitalPulseSoftware/NazaraEngine

--- a/projets/utopia.md
+++ b/projets/utopia.md
@@ -2,6 +2,6 @@
 
 Jeu de programmation en réseau dont le développement est streamé sur Twitch.
 
-Auteur: Lynix#9999 (83928726282174464)
+Auteur: Lynix#3516 (83928726282174464)
 Description du salon: Jeu de programmation en réseau dont le développement est streamé sur Twitch: https://github.com/DigitalPulseSoftware/Erewhon-Game
 https://www.twitch.tv/sirlynixvanfrietjes

--- a/staff.md
+++ b/staff.md
@@ -4,7 +4,7 @@ Liste des membres du serveur ayant des droits sur sa gestion et sa modération.
 
 ## Administrateurs
 
-- Lynix#9999 (83928726282174464)
+- Lynix#3516 (83928726282174464)
 - Razakhel#0632 (141863139871293441)
 
 ## Modérateurs


### PR DESCRIPTION
Modification du tag discord de lynix dans staff.md, projets/utopia.md, projets/nazara.md et live/sirlynixvanfrietjes.md.