### PR TITLE
correction de typo mineurs

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -1,4 +1,4 @@
-## Moeurs
+## Mœurs
 
 ### Les salons
 
@@ -20,9 +20,9 @@ Les salons où les discussions hors-sujet sont les bienvenues sont #discussions 
 
 La plupart des salons sont invisibles, vous pouvez les rendre visibles via le menu se trouvant dans #rejoindre-les-canaux.
 
-### L'aide en messages privés (`!mp`)
+### L'aide en message privé (`!mp`)
 
-Sur Not a Name, on ne préconise pas l'aide en message privé. Votre problème est peut-être partagé par un autre membre, ou votre question peut en intéresser d'autres. De plus, si une unique personne vous aide et que sa façon de faire est déconseillée, vous vous retrouverez avec d'autres problèmes sur les bras; là ou une multitude d'autres membres auraient souligné ces mauvaises pratiques.
+Sur Not a Name, on ne préconise pas l'aide en message privé. Votre problème est peut-être partagé par un autre membre, ou votre question peut en intéresser d'autres. De plus, si une unique personne vous aide et que sa façon de faire est déconseillée, vous vous retrouverez avec d'autres problèmes sur les bras ; là ou une multitude d'autres membres auraient souligné ces mauvaises pratiques.
 
 ### L'aide en vocal (`!vocal`)
 
@@ -75,9 +75,9 @@ Le scraping de données est la pratique de programmatiquement télécharger des 
 
 Le scraping n'est pas correctement couvert par un cadre légal. Sur NaN, nous n'autorisons le web-scraping que lorsque celui-ci peut s'effectue le respect strict des conditions d'utilisation du site en question. En d'autres termes, lorsqu'un site propose une API et que vous voulez interagir avec ce site : vous *devez* utiliser cette API.
 
-Toute demande d'aide concernant le scraping web doit être accompagné d'une référence vers le passage qui autorise le scraping dans les CGU du site. À défaut, la demande d'aide tombera sous la règle concernant le respect de la loi et sera classée sans suite.
+Toute demande d'aide concernant le web-scraping doit être accompagné d'une référence vers le passage qui autorise le scraping dans les CGU du site. À défaut, la demande d'aide tombera sous la règle concernant le respect de la loi et sera classée sans suite.
 
-Plus d'informations sur l'état du cadre légal du scraping web : <https://lexing.be/le-scraping-est-il-legal/>.
+Plus d'informations sur l'état du cadre légal du web-scraping : <https://lexing.be/le-scraping-est-il-legal/>.
 
 ## Salons Modérés
 

--- a/faq.md
+++ b/faq.md
@@ -73,7 +73,7 @@ Il n'y a personne qui est à la fois habitué, experte reconnue du domaine et qu
 
 Le scraping de données est la pratique de programmatiquement télécharger des données depuis un site. Il est possible de scraper en forgeant des requêtes HTTP ou bien en automatisant un navigateur web.
 
-Le scraping n'est pas correctement couvert par un cadre légal. Sur NaN, nous n'autorisons le web-scraping que lorsque celui-ci peut s'effectue le respect strict des conditions d'utilisation du site en question. En d'autres termes, lorsqu'un site propose une API et que vous voulez interagir avec ce site : vous *devez* utiliser cette API.
+Le scraping n'est pas correctement couvert par un cadre légal. Sur NaN, nous n'autorisons le web-scraping que lorsque celui-ci peut s'effectuer dans le respect strict des conditions d'utilisation du site en question. En d'autres termes, lorsqu'un site propose une API et que vous voulez interagir avec ce site : vous *devez* utiliser cette API.
 
 Toute demande d'aide concernant le web-scraping doit être accompagné d'une référence vers le passage qui autorise le scraping dans les CGU du site. À défaut, la demande d'aide tombera sous la règle concernant le respect de la loi et sera classée sans suite.
 

--- a/regles.md
+++ b/regles.md
@@ -1,7 +1,7 @@
 Bienvenue sur NaN (Not a Name), serveur Discord sur le thème de la programmation. L’objectif du serveur est de fournir un endroit d’échange convivial et agréable. Nous mettons à disposition plusieurs canaux dédiés aux différents langages et domaines de l’informatique.
 
 
-En utilisant Discord, vous vous êtes engagés à respecter la charte de bonne conduite : <https://discord.com/guidelines/>.
+En utilisant Discord, vous vous êtes engagés à respecter la charte de bonne conduite : <https://discord.com/guidelines>.
 
 La 1e règle du serveur est essentielle au maintien d'une ambiance propice au débat, à l'aide apportée aux nouveaux et plus généralement à un travail serein. Le staff se réserve le droit de mettre un terme aux débats foireux, aux dramas et aux autres dérives.
 

--- a/regles.md
+++ b/regles.md
@@ -1,7 +1,7 @@
 Bienvenue sur NaN (Not a Name), serveur Discord sur le thème de la programmation. L’objectif du serveur est de fournir un endroit d’échange convivial et agréable. Nous mettons à disposition plusieurs canaux dédiés aux différents langages et domaines de l’informatique.
 
 
-En utilisant Discord, vous vous êtes engagés à respecter la charte de bonne conduite : <https://discord.com/guidelines>.
+En utilisant Discord, vous vous êtes engagés à respecter la charte de bonne conduite : <https://discord.com/guidelines/>.
 
 La 1e règle du serveur est essentielle au maintien d'une ambiance propice au débat, à l'aide apportée aux nouveaux et plus généralement à un travail serein. Le staff se réserve le droit de mettre un terme aux débats foireux, aux dramas et aux autres dérives.
 
@@ -11,7 +11,7 @@ Cela comprend la façon de débattre, de poser des questions, de répondre à ce
 
 **2. La loi française est d'application sur le serveur.** (`!borderline`)
 
-Les contenus illégaux, le piratage, la pornographie, le gore, etc. sont interdits. Les sujets borderlines, ceux a la légalité douteuse ou dont l'usage n'est pas clairement dans les limites légales sont également interdits. Ce n'est pas parce que d'autres pratiquent des activités illégales que vous avez le droit d'en faire autant.
+Les contenus illégaux, le piratage, la pornographie, le gore, etc. sont interdits. Les sujets borderlines, ceux à la légalité douteuse ou dont l'usage n'est pas clairement dans les limites légales sont également interdits. Ce n'est pas parce que d'autres pratiquent des activités illégales que vous avez le droit d'en faire autant.
 
 **3. La publicité, la présentation des projets et les messages de recrutements sont soumis à une règlementation accrue.** (`!recrutement`)
 

--- a/regles.md
+++ b/regles.md
@@ -11,7 +11,7 @@ Cela comprend la façon de débattre, de poser des questions, de répondre à ce
 
 **2. La loi française est d'application sur le serveur.** (`!borderline`)
 
-Les contenus illégaux, le piratage, la pornographie, le gore, etc. sont interdits. Les sujets borderlines, ceux à la légalité douteuse ou dont l'usage n'est pas clairement dans les limites légales sont également interdits. Ce n'est pas parce que d'autres pratiquent des activités illégales que vous avez le droit d'en faire autant.
+Les contenus illégaux, le piratage, la pornographie, le gore, etc. sont interdits. Les sujets borderlines, ceux a la légalité douteuse ou dont l'usage n'est pas clairement dans les limites légales sont également interdits. Ce n'est pas parce que d'autres pratiquent des activités illégales que vous avez le droit d'en faire autant.
 
 **3. La publicité, la présentation des projets et les messages de recrutements sont soumis à une règlementation accrue.** (`!recrutement`)
 
@@ -23,7 +23,7 @@ Utiliser un langage dit SMS à outrance est interdit. Nous vous demandons égale
 
 **5. Le serveur se veut dans l'ensemble sérieux.**
 
-Si il existe des salons prévus aux discussions diverses (#discussions et #detente), c'est pour que les autres salons puissent rester centrés sur leurs domaines.
+S'il existe des salons prévus aux discussions diverses (#discussions et #detente), c'est pour que les autres salons puissent rester centrés sur leurs domaines.
 
 **6. Le serveur a ses habitudes.**
 


### PR DESCRIPTION
Vu que je suis lent j'ai peu le temps de suggérer ces erreurs avant le merge (my bad).
Aussi : `- :arrow_double_up: : Indique que la réponse à votre question se trouve un peu plus haut dans la conversation.` ce serait pas `haute` au lieu de `haut` (je sais, moi aussi ça me fait bizarre).