### PR TITLE
add "Culte du Code" in the security guideline

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -77,7 +77,7 @@ Parce que sur ce serveur il y a aussi beaucoup de novices en informatique, nous 
 
 Il n'y a personne qui est à la fois habitué, expert reconnu du domaine et qui voudrait devenir ambassadeur d'un canal sécurité. De ce fait, nous ne pouvons pas garantir que les discussions concernant le *pentesting*, le *reverse engineering* et d'autres formes de crack/hack se déroulent dans un cadre déontologique. Ces discussions sont interdites sur NaN.
 
-En attendant de trouver un candidat pour un futur salon sécu-info, vous pouvez vous intéresser aux autres serveurs discord de la sphère francophone. L'un de ces serveurs est Culte du Code, chez eux discuter sécu-info est le bienvenu. Pensez à leur rendre visite ! https://discord.com/invite/VXyWvdK
+En attendant de trouver un candidat pour un futur salon sécu-info, vous pouvez vous intéresser aux autres serveurs discord de la sphère francophone. L'un de ces serveurs est [Culte du Code](https://discord.gg/VXyWvdK), chez eux discuter sécu-info est le bienvenu. Pensez à leur rendre visite : https://discord.gg/VXyWvdK !
 
 ### Web-scraping
 


### PR DESCRIPTION
"Code du Code" is a french community where it is possible to discuss about
security. They offer an environment that is proper ethical-wise and that fit
NaN's opinion on what should a security communty looks like and behave.

Until we have our own workforce capable of enforcing such ethical
considerations in a dedicated channel. Advertising another discord server
is a good middle ground.