### PR TITLE
Guideline concernant les débats

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -47,6 +47,14 @@ En ce qui concerne la fonctionnalité "répondre" de discord, celle-ci sert surt
 
 Ceux qui ne sont pas dérangés par les notifications peuvent se renommer pour ajouter l'emoticon 🛎️ `:bellhop_bell:` à leur pseudo.
 
+### A propos des débats
+
+Les débats doivent se dérouler dans le calme et chaque parti doit faire preuve d'honnêteté et de charité intellectuelle. Faire preuve d'honnêteté intellectuelle c'est oser se remettre en question, avancer des sources les plus neutres et fiables possibles et correctement contextualiser son propos. Faire preuve de charité intellectuelle c'est chercher à avoir l'interprétation la plus positive possible du discours des autres.  À l'inverse, véhiculer des idées toutes faites, mal sourcées ou sortie de leur contexte dans le seul but de convaincre n'est pas de l'honnêteté intellectuelle.
+
+Le but d'un débat est de comprendre où se situe le vrai, l’imprécis et le faux. Il s'agit aussi de mieux comprendre les idées et opinions de tout un chacun pour enrichir sa propre vision du monde.
+
+De ce fait les propos négationnistes, faux, trompeurs, démagogues, trop virulents ou contraire au consensus scientifique n'ont pas leur place sur NaN. En accord avec la charte de Discord, le staff se réserve le droit de mettre fin à tout débat qui s'avère stérile voire de sanctionner les individus qui se seraient démarqués par leur incapacité à débattre.
+
 ### Les ambassadeurs
 
 Les ambassadeurs sont des membres habitués qui font un travail de fond dans le salon technique dont ils sont ambassadeurs. Ils assurent la pérennité des échanges, animent leurs salons et servent de pont avec le staff. Ils sont également à l'origine de l'organisation des défis.


### PR DESCRIPTION
Il y a régulièrement des débats dans les salons #discussions et
detente, il n'est pas rare que ces débats débordent et que le staff soit
obligé d'intervenir pour mettre fin au débat.

Si au fil du temps une certaine "ligne éditoriale" s'est mise en place,
cette ligne n'est pas forcément claire pour tout le monde et s'en
suivent parfoit des discussions houleuses. Pour rappel, cette ligne est
surtout: pro droits humains, pro loi, pro consensus-scientifique,
pro media, pro démocratie.

Avec cette nouvelle guideline à propos des débats, nous précisons la
manière de débattre sur NaN et nous distilons en filigrane cette fameuse
ligne éditoriale. Nous rappelons aussi que le staff est en droit de
prendre des mesures de modération en accord avec la Charte de discord:

> Ne partagez pas d’informations fausses ou trompeuses (autrement
> appelées désinformation).[1]

Co-authored-by: Charles
Co-authored-by: Jérôme Leclercq <lynix680@gmail.com>
Co-authored-by: Julien Castiaux <julien.castiaux@gmail.com>
Co-authored-by: RemQB

[1]: https://discord.com/guidelines, version du 25 février 2022
