### PR TITLE
Improve !code command

### DIFF
--- a/commandes-bots.md
+++ b/commandes-bots.md
@@ -31,17 +31,14 @@ NaN ne cautionne pas l'aide apportée sur des sujets où la légalité est doute
 
 ### code
 
-```markdown
-Poster du code (`!code`)
-
-Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :
-
-<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-soulign%C3%A9>.
-
-Si jamais votre code est beaucoup trop long pour tenir en un message ou que vous remplissez votre écran avec, il existe des sites pour poster vos codes. Il vous suffit de copier-coller votre code dans le site et de le sauvegarder, vous serez redirigés sur une page où votre code a été sauvegardé et vous pourrez copier-coller l'URL unique sur Discord.
-
-- <https://paste.artemix.org/>
-- <https://bin.readthedocs.fr/>
+```json
+{
+  "embed":{
+    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-soulign%C3%A9>.\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot de votre code directement.",
+    "title":"Poster du code (`!code`)",
+    "color":8323199
+  }
+}
 ```
 
 ### configpc

--- a/commandes-bots.md
+++ b/commandes-bots.md
@@ -34,7 +34,7 @@ NaN ne cautionne pas l'aide apportée sur des sujets où la légalité est doute
 ```json
 {
   "embed":{
-    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-soulign%C3%A9>.\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot/photo de votre code directement.",
+    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-souligné>.\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot/photo de votre code directement.",
     "title":"Poster du code (`!code`)",
     "color":8323199
   }

--- a/commandes-bots.md
+++ b/commandes-bots.md
@@ -34,7 +34,7 @@ NaN ne cautionne pas l'aide apportée sur des sujets où la légalité est doute
 ```json
 {
   "embed":{
-    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-soulign%C3%A9>.\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot de votre code directement.",
+    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-soulign%C3%A9>.\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot/photo de votre code directement.",
     "title":"Poster du code (`!code`)",
     "color":8323199
   }

--- a/commandes-bots.md
+++ b/commandes-bots.md
@@ -34,7 +34,7 @@ NaN ne cautionne pas l'aide apportée sur des sujets où la légalité est doute
 ```json
 {
   "embed":{
-    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n<https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-souligné>.\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot/photo de votre code directement.",
+    "description":"Pour les non-connaisseurs de Discord, il existe un moyen de poster du code bien formaté, lisible et coloré. Référez-vous à la documentation de Discord :\n\n[Documentation Discord](https://support.discord.com/hc/fr/articles/210298617-Bases-de-la-mise-en-forme-de-texte-Markdown-mise-en-forme-du-chat-gras-italique-souligné)\n\nSi votre code est assez long, preferez plutôt l'envoi d'un fichier (avec la bonne extension!) directement, Discord saura le mettre en forme pour qu'on puisse le lire ou le télécharger.\n\nMerci de **ne pas envoyer** de screenshot/photo de votre code directement.",
     "title":"Poster du code (`!code`)",
     "color":8323199
   }


### PR DESCRIPTION
Bonsoir à tous !

Comme discuté à plusieurs reprises notamment dans #42, mais aussi sur le serveur; la commande `!code` est un peu incomplète.
Le probleme reporté dans #42 concernant la documentation discord a été reglé par le staff discord, mais d'autres améliorations/idées se sont glissées depuis dans les diverses discussions parmis lesquelles deux principales:
- Le fait de préciser de ne pas envoyer de screenshot/photo de code
- Utiliser la fonctionnalité de visionnage des fichiers de code de discord directement au lieu des divers pastebins (pouvant être intégré aussi de manière automatique à NotABot par la suite - https://github.com/DigitalPulseSoftware/NotaBot/issues/62)

Voici donc une petite PR pour améliorer tout ca !

![image](https://user-images.githubusercontent.com/7013446/195681928-a14dfd1e-a6e3-4f42-8527-a77177337337.png)
