### PR TITLE
Update staff.md

### DIFF
--- a/staff.md
+++ b/staff.md
@@ -2,15 +2,12 @@
 
 Liste des membres du serveur ayant des droits sur sa gestion et sa modération.
 
-## Administrateurs
-
-- **Lynix#3516** (83928726282174464)
-
-## Modérateurs
+## Staff
 
 - **Charles#1065** (228622678901260290)
 - **Dr Lazor#6737** (87605725857058816)
 - **Elanis#0559** (193048878017150979)
+- **Lynix#3516** (83928726282174464)
 - **REMqb#8214** (278688001431961602)
 
 ## Ambassadeurs


### PR DESCRIPTION
Il n'y a plus de distinction entre les admins et les modos sur NaN et le terme "staff" s'est imposé comme désignant l'ensemble des personnes avec droits de modérations et d'administration.